### PR TITLE
Build `htop` from source so that it can see host's processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Using a build stage in order to build htop using /proc_host
-# as its default processes mount point instead of /proc.
+# Using a build stage in order to build htop using the flag `--with-proc=/proc_host`
+# which allows it to use a custom location instead of `/proc`.
 FROM alpine:3.6 as builder
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,21 @@
+# Using a build stage in order to build htop using /proc_host
+# as its default processes mount point instead of /proc.
+FROM alpine:3.6 as builder
+
+WORKDIR /build
+RUN apk add --update alpine-sdk build-base ncurses-dev autoconf automake curl unzip
+RUN curl -L https://github.com/hishamhm/htop/archive/master.zip --output htop.zip
+RUN unzip htop.zip
+RUN cd htop-master
+
+WORKDIR /build/htop-master
+RUN sh autogen.sh
+RUN sh configure --prefix=/build/htop-master/dist --with-proc=/proc_host
+RUN make
+RUN make install
+
+
+# Main Container
 FROM alpine:3.6
 
 MAINTAINER Jonatha Daguerre <jonatha@daguerre.com.br>
@@ -6,7 +24,6 @@ RUN apk add --no-cache \
         bash \
         bind-tools \
         curl \
-        htop \
         iptraf-ng \
         iotop \
         jq \
@@ -19,3 +36,4 @@ RUN apk add --no-cache \
         tcpdump \
         vim
 
+COPY --from=builder /build/htop-master/dist/bin/htop /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project focus on providing system administration and troubleshooting tools 
 
 Use `--net=host` allows `tcpdump` to access the host's network interfaces.
 
-Use `-v /proc:/proc_host` allows `htop` to watch the host's processes.
+Use `-v /proc:/proc_host` allows `htop` to watch the host's processes. Note that `htop` is unable to kill any host's processes.
 
 Optionally you can create a local directory and map it to the container like `-v /tmp/data/:/tmp/data/`:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project focus on providing system administration and troubleshooting tools 
 * **bash** - GNU Bourne-Again SHell.
 * **bind-tools** - The ISC DNS tools (dig, nslookup, host).
 * **curl** - Tool to transfer data from or to a server.
-* **htop** - A ncurses-based process viewer for Linux.
+* **htop** - A ncurses-based process viewer for Linux. (built from source, allows to watch the **host's processes**)
 * **iotop** - Simple top-like I/O monitor.
 * **iptraf-ng** - An IP Network Monitoring tool.
 * **jq** - Commandline JSON processor.
@@ -27,7 +27,9 @@ This project focus on providing system administration and troubleshooting tools 
 
 Use `--net=host` allows `tcpdump` to access the host's network interfaces.
 
-Optionally you can create a local directory and map it to the container:
+Use `-v /proc:/proc_host` allows `htop` to watch the host's processes.
+
+Optionally you can create a local directory and map it to the container like `-v /tmp/data/:/tmp/data/`:
 
 ```bash
 mkdir /tmp/data
@@ -36,6 +38,7 @@ docker run \
     --rm \
     --name toolkit \
     --net=host \
+    -v /proc:/proc_host \
     -v /tmp/data/:/tmp/data/ \
     -it \
     jonathadv/admin-toolkit \


### PR DESCRIPTION
Building `htop` from [source](https://github.com/hishamhm/htop) allows us to change the default  processes mount point from `/proc` to any other point by running `./configure --with-proc=<other directory>`. The new place has been set to `/proc_host` (and it should be mapped when running docker container, otherwise `htop` won't work). This pull request fixes: issue https://github.com/jonathadv/docker-admin-toolkit/issues/3.

In spite of the fact `htop` to be  able to watch and make some read operations over host's processes, it'is not able to **kill** any process from the host.

